### PR TITLE
feat(auth-ui): support OTP and password login/signup flows

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,26 +1,38 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
-import { Button, TextField, Flex, Card, Heading, Text } from '@radix-ui/themes';
+import {
+  Button,
+  TextField,
+  Flex,
+  Card,
+  Heading,
+  Text,
+} from '@radix-ui/themes';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'react-hot-toast';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '@/store';
+import {
+  loadUserThunk,
+  loginStartThunk,
+  loginWithPasswordThunk,
+} from '@/store/slices/authSlice';
+import { useState } from 'react';
 
 interface LoginFormData {
   phoneNumber: string;
+  password?: string;
 }
-
-// Redux
-import { useDispatch } from "react-redux";
-import { AppDispatch } from "@/store";
-import { loginStartThunk, resendOTPThunk } from "@/store/slices/authSlice";
 
 export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const returnUrl = searchParams.get('returnUrl') || '/explore';
 
+  const [loginMode, setLoginMode] = useState<'OTP' | 'PASSWORD'>('OTP');
+
   const dispatch = useDispatch<AppDispatch>();
-  // const { loading, error } = useSelector((state: RootState) => state.auth);
 
   const {
     register,
@@ -30,39 +42,51 @@ export default function LoginForm() {
 
   const onSubmit = async (data: LoginFormData) => {
     try {
-      // Login Start
-      await dispatch(loginStartThunk(data.phoneNumber)).unwrap();
-      // Redirect to OTP verification page with phone number AND returnUrl
-      router.push(
-        `/auth/verify-otp?phone=${encodeURIComponent(
-          data.phoneNumber
-        )}&returnUrl=${encodeURIComponent(returnUrl)}`
-      );
-      toast.success('OTP sent to your phone number');
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      if (errorMessage.includes('User not found')) {
-        toast.error('User not found. Please Sign Up first.');
-      } else if (errorMessage.includes('User must verify their phone first')) {
-        // Auto-handle unverified user: Resend OTP and redirect
-        try {
-          await dispatch(resendOTPThunk(data.phoneNumber)).unwrap();
-          toast.success('Account exists. OTP resent!');
-          router.push(
-            `/auth/verify-otp?phone=${encodeURIComponent(
-              data.phoneNumber
-            )}&returnUrl=${encodeURIComponent(returnUrl)}`
-          );
-        } catch {
-          toast.error('Failed to resend OTP for verification.');
-        }
+      if (loginMode === 'OTP') {
+        await dispatch(loginStartThunk(data.phoneNumber)).unwrap();
+
+        router.push(
+          `/auth/verify-otp?phone=${encodeURIComponent(
+            data.phoneNumber
+          )}&returnUrl=${encodeURIComponent(returnUrl)}`
+        );
+
+        toast.success('OTP sent to your phone number 📲');
       } else {
-        toast.error(`Failed to send OTP. Please try again : ${errorMessage}`);
+        if (!data.password) {
+          toast.error('Password is required');
+          return;
+        }
+
+        await dispatch(
+          loginWithPasswordThunk({
+            phoneNumber: data.phoneNumber,
+            password: data.password,
+          })
+        ).unwrap();
+        await dispatch(loadUserThunk());
+        toast.success('Login successful 🔥');
+        
+        router.replace(returnUrl);
+        router.refresh();
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      // Smart UX handling
+      if (errorMessage.includes('password not set')) {
+        toast.error('Use OTP login for this account');
+      } else if (errorMessage.includes('Invalid credentials')) {
+        toast.error('Wrong password');
+      } else if (errorMessage.includes('User not found')) {
+        toast.error('User not found. Please sign up.');
+      } else {
+        toast.error(errorMessage);
       }
     }
   };
 
-  // Handle Sign Up
   const handleSignUp = () => {
     router.push('/auth/signup');
   };
@@ -71,8 +95,31 @@ export default function LoginForm() {
     <Card size="4" className="max-w-md w-full">
       <Flex direction="column" gap="4">
         <Heading size="6" align="center">
-          Login with Phone Number
+          Login
         </Heading>
+
+        {/* 🔥 Toggle FIRST (better UX) */}
+        <Flex justify="center" gap="3">
+          <Button
+            variant={loginMode === 'OTP' ? 'solid' : 'soft'}
+            onClick={() => setLoginMode('OTP')}
+          >
+            OTP
+          </Button>
+
+          <Button
+            variant={loginMode === 'PASSWORD' ? 'solid' : 'soft'}
+            onClick={() => setLoginMode('PASSWORD')}
+          >
+            Password
+          </Button>
+        </Flex>
+
+        <Text size="1" align="center" color="gray">
+          {loginMode === 'OTP'
+            ? 'We’ll send you a one-time code'
+            : 'Enter your password to continue'}
+        </Text>
 
         <form onSubmit={handleSubmit(onSubmit)}>
           <Flex direction="column" gap="4">
@@ -88,14 +135,44 @@ export default function LoginForm() {
                 },
               })}
             />
+
             {errors.phoneNumber && (
               <Text color="red" size="2">
                 {errors.phoneNumber.message}
               </Text>
             )}
 
+            {loginMode === 'PASSWORD' && (
+              <>
+                <TextField.Root
+                  size="3"
+                  placeholder="Password"
+                  type="password"
+                  {...register('password', {
+                    required: loginMode === 'PASSWORD',
+                    minLength: {
+                      value: 6,
+                      message: 'Minimum 6 characters',
+                    },
+                  })}
+                />
+
+                {errors.password && (
+                  <Text color="red" size="2">
+                    {errors.password.message}
+                  </Text>
+                )}
+              </>
+            )}
+
             <Button size="3" type="submit" disabled={isSubmitting}>
-              {isSubmitting ? 'Sending OTP...' : 'Send OTP'}
+              {isSubmitting
+                ? loginMode === 'OTP'
+                  ? 'Sending OTP...'
+                  : 'Logging in...'
+                : loginMode === 'OTP'
+                ? 'Send OTP'
+                : 'Login'}
             </Button>
           </Flex>
         </form>

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -1,20 +1,34 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button, TextField, Flex, Card, Heading, Text } from "@radix-ui/themes";
+import {
+  Button,
+  TextField,
+  Flex,
+  Card,
+  Heading,
+  Text,
+} from "@radix-ui/themes";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { signupThunk } from "@/store/slices/authSlice";
+import {
+  signupThunk,
+  signupWithPasswordThunk,
+} from "@/store/slices/authSlice";
 import { AppDispatch, RootState } from "@/store";
 
 interface SignupFormData {
   phoneNumber: string;
+  password?: string;
 }
 
 export const SignupForm = () => {
+  const [signupMode, setSignupMode] = useState<"OTP" | "PASSWORD">("OTP");
+
   const {
     register,
     handleSubmit,
@@ -28,30 +42,60 @@ export const SignupForm = () => {
 
   const onSubmit = async (data: SignupFormData) => {
     try {
-      await dispatch(
-        signupThunk({ phoneNumber: data.phoneNumber })
-      ).unwrap();
+      if (signupMode === "OTP") {
+        await dispatch(
+          signupThunk({ phoneNumber: data.phoneNumber })
+        ).unwrap();
 
-      toast.success("Account created successfully!");
-      router.push(
-        `/auth/verify-otp?phone=${encodeURIComponent(data.phoneNumber)}`
-      );
+        toast.success("OTP sent 📲");
+
+        router.push(
+          `/auth/verify-otp?phone=${encodeURIComponent(
+            data.phoneNumber
+          )}`
+        );
+      } else {
+        if (!data.password) {
+          toast.error("Password is required");
+          return;
+        }
+
+        await dispatch(
+          signupWithPasswordThunk({
+            phoneNumber: data.phoneNumber,
+            password: data.password,
+          })
+        ).unwrap();
+
+        toast.success("Account created successfully 🔥");
+
+        router.push("/explore");
+      }
     } catch (err: unknown) {
       const error = err as {
         validationErrors?: Array<{ field: string; message: string }>;
         message?: string;
       };
-      // Handle validation errors
-      if (error?.validationErrors && Array.isArray(error.validationErrors)) {
-        error.validationErrors.forEach((err_item: { field: string; message: string }) => {
-          setError(err_item.field as keyof SignupFormData, { type: "server", message: err_item.message });
+
+      if (error?.validationErrors) {
+        error.validationErrors.forEach((err_item) => {
+          setError(err_item.field as keyof SignupFormData, {
+            type: "server",
+            message: err_item.message,
+          });
         });
         return;
       }
 
-      // Handle general error message
-      const errorMessage = error?.message || (typeof error === "string" ? error : "Signup failed");
-      toast.error(errorMessage);
+      const errorMessage =
+        error?.message ||
+        (typeof error === "string" ? error : "Signup failed");
+
+      if (errorMessage.includes("already exists")) {
+        toast.error("User already exists. Try logging in.");
+      } else {
+        toast.error(errorMessage);
+      }
     }
   };
 
@@ -62,9 +106,31 @@ export const SignupForm = () => {
           Create Your Account
         </Heading>
 
+        {/* 🔥 Toggle */}
+        <Flex justify="center" gap="3">
+          <Button
+            variant={signupMode === "OTP" ? "solid" : "soft"}
+            onClick={() => setSignupMode("OTP")}
+          >
+            OTP
+          </Button>
+
+          <Button
+            variant={signupMode === "PASSWORD" ? "solid" : "soft"}
+            onClick={() => setSignupMode("PASSWORD")}
+          >
+            Password
+          </Button>
+        </Flex>
+
+        <Text size="1" align="center" color="gray">
+          {signupMode === "OTP"
+            ? "We’ll verify your phone with OTP"
+            : "Create account with password"}
+        </Text>
+
         <form onSubmit={handleSubmit(onSubmit)}>
           <Flex direction="column" gap="4">
-
             <TextField.Root
               size="3"
               placeholder="Phone Number"
@@ -77,14 +143,43 @@ export const SignupForm = () => {
                 },
               })}
             />
+
             {errors.phoneNumber && (
               <Text color="red" size="2">
                 {errors.phoneNumber.message}
               </Text>
             )}
 
+            {/* 🔥 Password Field */}
+            {signupMode === "PASSWORD" && (
+              <>
+                <TextField.Root
+                  size="3"
+                  placeholder="Password"
+                  type="password"
+                  {...register("password", {
+                    required: signupMode === "PASSWORD",
+                    minLength: {
+                      value: 6,
+                      message: "Minimum 6 characters",
+                    },
+                  })}
+                />
+
+                {errors.password && (
+                  <Text color="red" size="2">
+                    {errors.password.message}
+                  </Text>
+                )}
+              </>
+            )}
+
             <Button size="3" type="submit" disabled={loading}>
-              {loading ? "Creating account..." : "Sign Up"}
+              {loading
+                ? "Creating account..."
+                : signupMode === "OTP"
+                ? "Send OTP"
+                : "Sign Up"}
             </Button>
           </Flex>
         </form>

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -4,7 +4,8 @@ import Cookies from 'js-cookie';
 
 const apiClient = axios.create({
   // baseURL: 'https://api.malicc.com/graphql',
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL: 'http://localhost:8000/graphql',
+  // process.env.NEXT_PUBLIC_API_BASE_URL ||
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,221 +1,304 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import {
-    signupAPI,
-    requestLoginOTPAPI,
-    verifyOTPAPI,
-    getMeAPI,
-    resendOTPAPI,
-    updateAdminCredentialsAPI,
-} from "../../services/auth.service";
-import { User, SignupInput } from "../../types/user";
-import Cookies from "js-cookie";
+  signupAPI,
+  requestLoginOTPAPI,
+  verifyOTPAPI,
+  getMeAPI,
+  resendOTPAPI,
+  updateAdminCredentialsAPI,
+} from '../../services/auth.service';
+import { User, SignupInput } from '../../types/user';
+import Cookies from 'js-cookie';
+import apiClient from '../../services/apiClient';
 
 interface AuthState {
-    user: User | null;
-    token: string | null;
-    isAuthenticated: boolean;
-    loading: boolean;
-    error: string | null;
-    otpSent: boolean;
-    verificationPhone: string | null; // Phone number to verify
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+  error: string | null;
+  otpSent: boolean;
+  verificationPhone: string | null; // Phone number to verify
 }
 
 const initialState: AuthState = {
-    user: null,
-    token: typeof window !== "undefined" ? Cookies.get("auth-token") || null : null,
-    isAuthenticated: false,
-    loading: false,
-    error: null,
-    otpSent: false,
-    verificationPhone: null,
+  user: null,
+  token:
+    typeof window !== 'undefined' ? Cookies.get('auth-token') || null : null,
+  isAuthenticated: false,
+  loading: false,
+  error: null,
+  otpSent: false,
+  verificationPhone: null,
 };
 
 // Async Thunks
 export const signupThunk = createAsyncThunk(
-    "auth/signup",
-    async (input: SignupInput, { rejectWithValue }) => {
-        try {
-            const response = await signupAPI(input);
-            if (!response) throw new Error("No response from server");
-            return { user: response.data.data.signup.user, input };
-        } catch (error) {
-            return rejectWithValue(error);
-        }
+  'auth/signup',
+  async (input: SignupInput, { rejectWithValue }) => {
+    try {
+      const response = await signupAPI(input);
+      if (!response) throw new Error('No response from server');
+      return { user: response.data.data.signup.user, input };
+    } catch (error) {
+      return rejectWithValue(error);
     }
+  }
 );
 
 export const loginStartThunk = createAsyncThunk(
-    "auth/loginStart",
-    async (phoneNumber: string, { rejectWithValue }) => {
-        try {
-            const response = await requestLoginOTPAPI(phoneNumber);
-            if (!response) throw new Error("No response from server");
-            return phoneNumber;
-        } catch (error) {
-            return rejectWithValue((error as Error).message || "Login failed");
-        }
+  'auth/loginStart',
+  async (phoneNumber: string, { rejectWithValue }) => {
+    try {
+      const response = await requestLoginOTPAPI(phoneNumber);
+      if (!response) throw new Error('No response from server');
+      return phoneNumber;
+    } catch (error) {
+      return rejectWithValue((error as Error).message || 'Login failed');
     }
+  }
 );
 
 export const verifyOTPThunk = createAsyncThunk(
-    "auth/verifyOTP",
-    async (
-        { phoneNumber, otp }: { phoneNumber: string; otp: string },
-        { rejectWithValue }
-    ) => {
-        try {
-            const response = await verifyOTPAPI(phoneNumber, otp);
-            if (!response) throw new Error("No response from server");
-            return response.data.data.verifyOTP;
-        } catch (error) {
-            return rejectWithValue((error as Error).message || "Verification failed");
-        }
+  'auth/verifyOTP',
+  async (
+    { phoneNumber, otp }: { phoneNumber: string; otp: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      const response = await verifyOTPAPI(phoneNumber, otp);
+      if (!response) throw new Error('No response from server');
+      return response.data.data.verifyOTP;
+    } catch (error) {
+      return rejectWithValue((error as Error).message || 'Verification failed');
     }
+  }
 );
 
 export const loadUserThunk = createAsyncThunk(
-    "auth/loadUser",
-    async (_, { rejectWithValue }) => {
-        try {
-            const response = await getMeAPI();
-            if (!response) throw new Error("No response from server");
-            return response.data.data.user;
-        } catch (error) {
-            return rejectWithValue((error as Error).message || "Failed to load user");
-        }
+  'auth/loadUser',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await getMeAPI();
+      if (!response) throw new Error('No response from server');
+      return response.data.data.user;
+    } catch (error) {
+      return rejectWithValue((error as Error).message || 'Failed to load user');
     }
-
+  }
 );
 
 export const resendOTPThunk = createAsyncThunk(
-    "auth/resendOTP",
-    async (phoneNumber: string, { rejectWithValue }) => {
-        try {
-            await resendOTPAPI(phoneNumber);
-            return phoneNumber;
-        } catch (error) {
-            return rejectWithValue((error as Error).message || "Failed to resend OTP");
-        }
+  'auth/resendOTP',
+  async (phoneNumber: string, { rejectWithValue }) => {
+    try {
+      await resendOTPAPI(phoneNumber);
+      return phoneNumber;
+    } catch (error) {
+      return rejectWithValue(
+        (error as Error).message || 'Failed to resend OTP'
+      );
     }
+  }
 );
 
+export const signupWithPasswordThunk = createAsyncThunk(
+  'auth/signupWithPassword',
+  async (
+    { phoneNumber, password }: { phoneNumber: string; password: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      const res = await apiClient.post('/graphql', {
+        query: `
+          mutation SignupWithPassword($input: SignupWithPasswordInput!) {
+            signupWithPassword(input: $input) {
+              token
+              user {
+                id
+                phoneNumber
+              }
+            }
+          }
+        `,
+        variables: {
+          input: { phoneNumber, password },
+        },
+      });
+
+      const data = res.data.data.signupWithPassword;
+
+      Cookies.set('auth-token', data.token, { expires: 7 });
+
+      return data;
+    } catch (err: any) {
+      return rejectWithValue(
+        err.response?.data?.errors?.[0]?.message || 'Signup failed'
+      );
+    }
+  }
+);
+export const loginWithPasswordThunk = createAsyncThunk(
+  'auth/loginWithPassword',
+  async (
+    { phoneNumber, password }: { phoneNumber: string; password: string },
+    { rejectWithValue, dispatch }
+  ) => {
+    try {
+      const res = await apiClient.post('/graphql', {
+        query: `
+          mutation LoginWithPassword($input: LoginPasswordInput!) {
+            loginWithPassword(input: $input) {
+              token
+              user {
+                id
+                phoneNumber
+                role
+              }
+            }
+          }
+        `,
+        variables: {
+          input: { phoneNumber, password },
+        },
+      });
+
+      const data = res.data.data.loginWithPassword;
+
+      // ✅ store token in cookie (same as OTP flow)
+      Cookies.set('auth-token', data.token, { expires: 7 });
+
+      // ✅ update redux properly
+      dispatch(setUser(data.user));
+
+      return data;
+    } catch (err: any) {
+      return rejectWithValue(
+        err.response?.data?.errors?.[0]?.message || 'Login failed'
+      );
+    }
+  }
+);
 // Update User
 export const updateUserThunk = createAsyncThunk(
-    "auth/updateUser",
-    async (input: { username?: string; email?: string }, { rejectWithValue }) => {
-        try {
-            const response = await updateAdminCredentialsAPI(input);
-            if (!response) throw new Error("No response from server");
-            return response.data.data.updateAdminCredentials;
-        } catch (error: unknown) {
-            return rejectWithValue(error instanceof Error ? error.message : "Failed to update user");
-        }
+  'auth/updateUser',
+  async (input: { username?: string; email?: string }, { rejectWithValue }) => {
+    try {
+      const response = await updateAdminCredentialsAPI(input);
+      if (!response) throw new Error('No response from server');
+      return response.data.data.updateAdminCredentials;
+    } catch (error: unknown) {
+      return rejectWithValue(
+        error instanceof Error ? error.message : 'Failed to update user'
+      );
     }
+  }
 );
 
 const authSlice = createSlice({
-    name: "auth",
-    initialState,
-    reducers: {
-        logout: (state) => {
-            state.user = null;
-            state.token = null;
-            state.isAuthenticated = false;
-            state.otpSent = false;
-            state.verificationPhone = null;
-            Cookies.remove("auth-token");
-        },
-        setUser: (state, action) => {
-            state.user = action.payload;
-        },
-        resetError: (state) => {
-            state.error = null;
-        }
+  name: 'auth',
+  initialState,
+  reducers: {
+    logout: (state) => {
+      state.user = null;
+      state.token = null;
+      state.isAuthenticated = false;
+      state.otpSent = false;
+      state.verificationPhone = null;
+      Cookies.remove('auth-token');
     },
-    extraReducers: (builder) => {
-        // Signup
-        builder.addCase(signupThunk.pending, (state) => {
-            state.loading = true;
-            state.error = null;
-        });
-        builder.addCase(signupThunk.fulfilled, (state, action) => {
-            state.loading = false;
-            state.otpSent = true;
-            state.verificationPhone = action.payload.input.phoneNumber;
-        });
-        builder.addCase(signupThunk.rejected, (state, action) => {
-            state.loading = false;
-            state.error = action.payload as string;
-        });
-
-        // Login Start
-        builder.addCase(loginStartThunk.pending, (state) => {
-            state.loading = true;
-            state.error = null;
-        });
-        builder.addCase(loginStartThunk.fulfilled, (state, action) => {
-            state.loading = false;
-            state.otpSent = true;
-            state.verificationPhone = action.payload;
-        });
-        builder.addCase(loginStartThunk.rejected, (state, action) => {
-            state.loading = false;
-            state.error = action.payload as string;
-        });
-
-        // Verify OTP
-        builder.addCase(verifyOTPThunk.pending, (state) => {
-            state.loading = true;
-            state.error = null;
-        });
-        builder.addCase(verifyOTPThunk.fulfilled, (state, action) => {
-            state.loading = false;
-            state.isAuthenticated = true;
-            state.token = action.payload.token;
-            state.user = action.payload.user;
-            state.otpSent = false;
-            state.verificationPhone = null;
-            Cookies.set("auth-token", action.payload.token, { expires: 7 });
-        });
-        builder.addCase(verifyOTPThunk.rejected, (state, action) => {
-            state.loading = false;
-            state.error = action.payload as string;
-        });
-
-        // Load User
-        builder.addCase(loadUserThunk.pending, (state) => {
-            state.loading = true;
-        });
-        builder.addCase(loadUserThunk.fulfilled, (state, action) => {
-            state.loading = false;
-            state.user = action.payload;
-            state.isAuthenticated = true;
-        });
-        builder.addCase(loadUserThunk.rejected, (state, action) => {
-            state.loading = false;
-            state.isAuthenticated = false;
-            state.user = null;
-            state.token = null;
-            state.error = action.payload as string;
-            Cookies.remove("auth-token");
-        });
-
-        // Update User
-        builder.addCase(updateUserThunk.pending, (state) => {
-            state.loading = true;
-            state.error = null;
-        });
-        builder.addCase(updateUserThunk.fulfilled, (state, action) => {
-            state.loading = false;
-            if (action.payload) {
-                state.user = action.payload;
-            }
-        });
-        builder.addCase(updateUserThunk.rejected, (state, action) => {
-            state.loading = false;
-            state.error = action.payload as string;
-        });
+    setUser: (state, action) => {
+      state.user = action.payload;
+      state.isAuthenticated = true;
     },
+    resetError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    // Signup
+    builder.addCase(signupThunk.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    });
+    builder.addCase(signupThunk.fulfilled, (state, action) => {
+      state.loading = false;
+      state.otpSent = true;
+      state.verificationPhone = action.payload.input.phoneNumber;
+    });
+    builder.addCase(signupThunk.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload as string;
+    });
+
+    // Login Start
+    builder.addCase(loginStartThunk.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    });
+    builder.addCase(loginStartThunk.fulfilled, (state, action) => {
+      state.loading = false;
+      state.otpSent = true;
+      state.verificationPhone = action.payload;
+    });
+    builder.addCase(loginStartThunk.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload as string;
+    });
+
+    // Verify OTP
+    builder.addCase(verifyOTPThunk.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    });
+    builder.addCase(verifyOTPThunk.fulfilled, (state, action) => {
+      state.loading = false;
+      state.isAuthenticated = true;
+      state.token = action.payload.token;
+      state.user = action.payload.user;
+      state.otpSent = false;
+      state.verificationPhone = null;
+      Cookies.set('auth-token', action.payload.token, { expires: 7 });
+    });
+    builder.addCase(verifyOTPThunk.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload as string;
+    });
+
+    // Load User
+    builder.addCase(loadUserThunk.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(loadUserThunk.fulfilled, (state, action) => {
+      state.loading = false;
+      state.user = action.payload;
+      state.isAuthenticated = true;
+    });
+    builder.addCase(loadUserThunk.rejected, (state, action) => {
+      state.loading = false;
+      state.isAuthenticated = false;
+      state.user = null;
+      state.token = null;
+      state.error = action.payload as string;
+      Cookies.remove('auth-token');
+    });
+
+    // Update User
+    builder.addCase(updateUserThunk.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    });
+    builder.addCase(updateUserThunk.fulfilled, (state, action) => {
+      state.loading = false;
+      if (action.payload) {
+        state.user = action.payload;
+      }
+    });
+    builder.addCase(updateUserThunk.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload as string;
+    });
+  },
 });
 
 export const { logout, resetError, setUser } = authSlice.actions;


### PR DESCRIPTION
- added toggle between OTP and password modes (login & signup)
- implemented loginWithPassword and signupWithPassword thunks
- unified auth token storage using cookies
- fixed auth state sync with Redux (setUser + loadUserThunk)
- improved redirect handling with returnUrl + router.replace